### PR TITLE
Fix multi-click settings bug

### DIFF
--- a/app/src/main/java/io/mochahub/powermeter/MainActivity.kt
+++ b/app/src/main/java/io/mochahub/powermeter/MainActivity.kt
@@ -8,6 +8,7 @@ import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.navigation.NavController
+import androidx.navigation.NavOptions
 import androidx.navigation.Navigation
 import androidx.navigation.ui.NavigationUI
 import com.microsoft.appcenter.AppCenter
@@ -60,7 +61,8 @@ class MainActivity : AppCompatActivity() {
 
         return when (item?.itemId) {
             R.id.action_settings -> {
-                Navigation.findNavController(this, R.id.nav_host_fragment).navigate(R.id.settingsFragment)
+                Navigation.findNavController(this, R.id.nav_host_fragment)
+                    .navigate(R.id.settingsFragment, null, NavOptions.Builder().setLaunchSingleTop(true).build())
                 return true
             }
             else -> super.onOptionsItemSelected(item)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,12 +9,11 @@
 
     <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
-            app:layout_constraintTop_toTopOf="parent"
-            app:theme="@style/ToolBarStyle"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="@color/colorPrimary"
-            />
+            app:layout_constraintTop_toTopOf="parent"
+            app:theme="@style/ToolBarStyle" />
 
     <fragment
             android:id="@+id/nav_host_fragment"

--- a/app/src/main/res/layout/fragment_exercise.xml
+++ b/app/src/main/res/layout/fragment_exercise.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_stats.xml
+++ b/app/src/main/res/layout/fragment_stats.xml
@@ -5,7 +5,7 @@
         android:layout_height="match_parent"
         android:orientation="vertical"
         tools:context=".stats.StatsFragment">
-    
+
 
     <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/stats_list"

--- a/app/src/main/res/layout/fragment_workout.xml
+++ b/app/src/main/res/layout/fragment_workout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/graph_fragment.xml
+++ b/app/src/main/res/layout/graph_fragment.xml
@@ -1,31 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_margin="16dp"
         tools:context=".graph.GraphFragment">
 
-        <TextView
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:id="@+id/graph_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+    <TextView
+            android:id="@+id/graph_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:id="@+id/graph_pr"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+    <TextView
+            android:id="@+id/graph_pr"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     <com.github.mikephil.charting.charts.LineChart
-            app:layout_constraintBottom_toBottomOf="parent"
             android:id="@+id/graph"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/row_stat.xml
+++ b/app/src/main/res/layout/row_stat.xml
@@ -10,23 +10,23 @@
     <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            >
-            <TextView
-                    android:id="@+id/card_title"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="16dp"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginBottom="8dp"
-                    android:textSize="18sp" />
-                <!-- TODO: Emjoi or small icon to the right of this container in line with title-->
+            android:orientation="vertical">
 
-            <TextView
-                    android:id="@+id/card_description"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="16dp"
-                    android:layout_marginBottom="8dp" />
+        <TextView
+                android:id="@+id/card_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                android:textSize="18sp" />
+        <!-- TODO: Emjoi or small icon to the right of this container in line with title-->
+
+        <TextView
+                android:id="@+id/card_description"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginBottom="8dp" />
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -1,32 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<navigation
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools" android:id="@+id/navigation"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/navigation"
         app:startDestination="@id/destination_workout_session_screen">
-    <fragment android:id="@+id/destination_workout_session_screen" android:name="io.mochahub.powermeter.workouts.WorkoutFragment"
-              android:label="fragment_workout" tools:layout="@layout/fragment_workout">
-        <action android:id="@+id/action_destination_workout_session_screen_to_destination_exercises_screen"
-                app:destination="@id/destination_exercises_screen"/>
-        <action android:id="@+id/action_destination_workout_session_screen_to_destination_stats_screen"
-                app:destination="@id/destination_stats_screen"/>
+    <fragment
+            android:id="@+id/destination_workout_session_screen"
+            android:name="io.mochahub.powermeter.workouts.WorkoutFragment"
+            android:label="fragment_workout"
+            tools:layout="@layout/fragment_workout">
+        <action
+                android:id="@+id/action_destination_workout_session_screen_to_destination_exercises_screen"
+                app:destination="@id/destination_exercises_screen" />
+        <action
+                android:id="@+id/action_destination_workout_session_screen_to_destination_stats_screen"
+                app:destination="@id/destination_stats_screen" />
     </fragment>
-    <fragment android:id="@+id/destination_stats_screen" android:name="io.mochahub.powermeter.stats.StatsFragment"
-              android:label="fragment_stats" tools:layout="@layout/fragment_stats">
-        <action android:id="@+id/action_destination_stats_screen_to_destination_exercises_screen"
-                app:destination="@id/destination_exercises_screen"/>
-        <action android:id="@+id/action_destination_stats_screen_to_destination_workout_session_screen"
-                app:destination="@id/destination_workout_session_screen"/>
+    <fragment
+            android:id="@+id/destination_stats_screen"
+            android:name="io.mochahub.powermeter.stats.StatsFragment"
+            android:label="fragment_stats"
+            tools:layout="@layout/fragment_stats">
+        <action
+                android:id="@+id/action_destination_stats_screen_to_destination_exercises_screen"
+                app:destination="@id/destination_exercises_screen" />
+        <action
+                android:id="@+id/action_destination_stats_screen_to_destination_workout_session_screen"
+                app:destination="@id/destination_workout_session_screen" />
         <action
                 android:id="@+id/action_destination_stats_screen_to_graphFragment"
                 app:destination="@id/graphFragment" />
     </fragment>
-    <fragment android:id="@+id/destination_exercises_screen" android:name="io.mochahub.powermeter.exercises.ExerciseFragment"
-              android:label="fragment_exercise" tools:layout="@layout/fragment_exercise">
-        <action android:id="@+id/action_destination_exercises_screen_to_destination_stats_screen"
-                app:destination="@id/destination_stats_screen"/>
-        <action android:id="@+id/action_destination_exercises_screen_to_destination_workout_session_screen"
-                app:destination="@id/destination_workout_session_screen"/>
+    <fragment
+            android:id="@+id/destination_exercises_screen"
+            android:name="io.mochahub.powermeter.exercises.ExerciseFragment"
+            android:label="fragment_exercise"
+            tools:layout="@layout/fragment_exercise">
+        <action
+                android:id="@+id/action_destination_exercises_screen_to_destination_stats_screen"
+                app:destination="@id/destination_stats_screen" />
+        <action
+                android:id="@+id/action_destination_exercises_screen_to_destination_workout_session_screen"
+                app:destination="@id/destination_workout_session_screen" />
     </fragment>
     <fragment
             android:id="@+id/graphFragment"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,5 +14,5 @@
         <item name="android:textColorSecondary">@android:color/white</item>
         <item name="actionMenuTextColor">@android:color/white</item>
     </style>
-    
+
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.3'
 


### PR DESCRIPTION
## Bug
If you click the settings icon in the tool bar and then click it again a few times, very time you click it you add the settings fragment to the back stack! Meaning to go back to the page you were on you need to click back that many times 🤣 

## Solution
[SingleTop](https://developer.android.com/reference/androidx/navigation/NavOptions.html#shouldLaunchSingleTop()) fixes this.

## An Aside
The rest of this PR includes: 
- An update for Grade from `3.5.2` to `3.5.3`
- Auto-cleaning the XML layout files (which is Option-CMD-L on Mac btw)

## Further Aside
The night mode manual setting doesn't override the android system setting night mode properly, so it breaks in ways I'm guessing you guys don't see since your phones always cede to the preferences 👀 