### PR TITLE
Fix bottom nav bar not showing page

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -32,9 +32,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-            android:background="@color/colorPrimary"
-            app:itemIconTint="@color/design_default_color_background"
-            app:itemTextColor="@color/design_default_color_background"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/nav_host_fragment"
             app:menu="@menu/menu_navigation" />


### PR DESCRIPTION
## Bug
The bottom nav bar currently doesn't show which page you're on which is a really weird and non-intuitive experience. This PR makes the [bottom nav follow the default style](https://material.io/develop/android/components/bottom-navigation-view/), which is `style="@style/Widget.MaterialComponents.BottomNavigationView"` which also happens to follow the rest of the app as far as night mode is concerned