### PR TITLE
Prevent duplicate exercises

### DIFF
--- a/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseFragment.kt
+++ b/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseFragment.kt
@@ -75,7 +75,7 @@ class ExerciseFragment : Fragment() {
             it?.let {
                 val currentExercises: List<String> = viewModel.exercises.value?.map { it.name } ?: listOf()
                 if (currentExercises.contains(it.name)) {
-                    Toast.makeText(requireContext(), "Exercise already exists!", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), getString(R.string.alert_exercise_exists), Toast.LENGTH_SHORT).show()
                 } else {
                     viewModel.addExercise(it.toDataModel())
                 }

--- a/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseFragment.kt
+++ b/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseFragment.kt
@@ -16,6 +16,7 @@ import com.google.android.material.snackbar.Snackbar
 import io.mochahub.powermeter.R
 import io.mochahub.powermeter.data.AppDatabase
 import io.mochahub.powermeter.data.Exercise
+import io.mochahub.powermeter.models.toDataModel
 import io.mochahub.powermeter.shared.SwipeToDeleteCallback
 import kotlinx.android.synthetic.main.fragment_exercise.*
 
@@ -72,7 +73,12 @@ class ExerciseFragment : Fragment() {
 
         newExerciseSharedViewModel.newExercise.observe(viewLifecycleOwner, Observer {
             it?.let {
-                viewModel.addExercise(Exercise(name = it.name, personalRecord = it.personalRecord, muscleGroup = it.muscleGroup))
+                val currentExercises: List<String> = viewModel.exercises.value?.map { it.name } ?: listOf()
+                if (currentExercises.contains(it.name)) {
+                    Toast.makeText(requireContext(), "Exercise already exists!", Toast.LENGTH_SHORT).show()
+                } else {
+                    viewModel.addExercise(it.toDataModel())
+                }
                 newExerciseSharedViewModel.clearNewExercise()
             }
         })

--- a/app/src/main/java/io/mochahub/powermeter/models/Exercise.kt
+++ b/app/src/main/java/io/mochahub/powermeter/models/Exercise.kt
@@ -1,12 +1,21 @@
 package io.mochahub.powermeter.models
 
+import io.mochahub.powermeter.data.Exercise as ExerciseDataModel
+
 data class Exercise(
     val name: String,
     val personalRecord: Double,
     val muscleGroup: String // TODO: Make MuscleGroup data/enum class?
 ) {
-
     override fun toString(): String {
         return "Exercise(name='$name', personalRecord='$personalRecord' muscleGroup='$muscleGroup')"
     }
+}
+
+/**
+ *  Not entirely sure how I feel about the db model and the existing model but this extension function
+ *  is a useful mapper from one to the other
+ */
+fun Exercise.toDataModel(): ExerciseDataModel {
+    return ExerciseDataModel(name = this.name, personalRecord = this.personalRecord, muscleGroup = this.muscleGroup)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,5 +10,6 @@
     <string name="muscle_group">Muscle Group</string>
     <string name="personal_record">Personal Record</string>
     <string name="name">Name</string>
+    <string name="alert_exercise_exists">Exercise already exists!</string>
 
 </resources>


### PR DESCRIPTION
The issue #35 was caused by the existence of duplicate exercises, so this prevents that by disallowing the creation of an existing exercise. 