### PR TITLE
Move Exercise CRUD over to IO thread

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,10 +78,15 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:3.2.0"
 
     // Room
-    implementation "android.arch.persistence.room:runtime:$room_version"
-    kapt "android.arch.persistence.room:compiler:$room_version"
+    implementation "androidx.room:room-runtime:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
 
     // Epoxy
     implementation "com.airbnb.android:epoxy:$epoxy_version"
     kapt "com.airbnb.android:epoxy-processor:$epoxy_version"
+
+    // Coroutines
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 }

--- a/app/src/main/java/io/mochahub/powermeter/data/AppDatabase.kt
+++ b/app/src/main/java/io/mochahub/powermeter/data/AppDatabase.kt
@@ -6,21 +6,24 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 
-@Database(entities = [ExerciseEntity::class], version = 1)
+@Database(entities = [ExerciseEntity::class], version = 1, exportSchema = false)
 @TypeConverters(DateTypeConverters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun exerciseDao(): ExerciseDao
 
     companion object {
-        @Volatile private var instance: AppDatabase? = null
+        @Volatile
+        private var instance: AppDatabase? = null
         private val LOCK = Any()
 
         operator fun invoke(context: Context) = instance ?: synchronized(LOCK) {
             instance ?: buildDatabase(context).also { instance = it }
         }
 
-        private fun buildDatabase(context: Context) = Room.databaseBuilder(context,
-            AppDatabase::class.java, "power-meter.db")
+        private fun buildDatabase(context: Context) = Room.databaseBuilder(
+            context,
+            AppDatabase::class.java, "power-meter.db"
+        )
             .build()
     }
 }

--- a/app/src/main/java/io/mochahub/powermeter/data/ExerciseDao.kt
+++ b/app/src/main/java/io/mochahub/powermeter/data/ExerciseDao.kt
@@ -12,15 +12,12 @@ interface ExerciseDao {
     @Query("SELECT * FROM exercises ORDER BY createdAt ASC")
     fun getAll(): LiveData<List<ExerciseEntity>>
 
-    @Query("SELECT * FROM exercises WHERE id = :id")
-    fun getById(id: Int): LiveData<ExerciseEntity>
-
     @Insert
-    fun insertAll(vararg exercise: ExerciseEntity)
+    suspend fun insertAll(vararg exercise: ExerciseEntity)
 
     @Delete
-    fun delete(exercise: ExerciseEntity)
+    suspend fun delete(exercise: ExerciseEntity)
 
     @Update
-    fun updateExercise(vararg exercise: ExerciseEntity)
+    suspend fun updateExercise(vararg exercise: ExerciseEntity)
 }

--- a/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseViewModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseViewModel.kt
@@ -2,30 +2,31 @@ package io.mochahub.powermeter.exercises
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import io.mochahub.powermeter.data.AppDatabase
 import io.mochahub.powermeter.data.ExerciseEntity
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class ExerciseViewModel(val db: AppDatabase) : ViewModel() {
     val exercises: LiveData<List<ExerciseEntity>> = db.exerciseDao().getAll()
 
     fun addExercise(exercise: ExerciseEntity) {
-        GlobalScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             db.exerciseDao().insertAll(exercise)
         }
     }
 
     fun removeExercise(position: Int): ExerciseEntity {
         val exercise = exercises.value!![position]
-        GlobalScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             db.exerciseDao().delete(exercise)
         }
         return exercise
     }
 
     fun updateExercise(exercise: ExerciseEntity) {
-        GlobalScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             db.exerciseDao().updateExercise(exercise)
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,8 @@ buildscript {
         ktx_version = "1.1.0"
         preference_version = "1.1.0"
         epoxy_version = "3.6.0"
-        room_version = "1.1.1"
+        room_version = "2.2.3"
+        coroutines_version = "1.1.1"
     }
     repositories {
         google()


### PR DESCRIPTION
1. Our Room Dependency was outdated so I updated that
2. Removed unused `getById` from Exercise Dao
3. Moved our database writes to IO thread instead of main thread
4. Also moved these ☝🏽to `viewModelScope` instead of `GlobalScope` which might or might not be a good idea... I feel like it's a good idea to scope them to the `ViewModel` lifecycle because why would we need any of these coroutines to live on after the death of the `ExerciseViewModel`? If there was a case where they took so long and we wanted them to survive I could imagine `GlobalScope` being better but I can't see that happening, and if it does happen we can always change it back later - as opposed to leaking coroutines right now