### PR TITLE
Update exposed dropdown

### DIFF
--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/NewWorkoutDialog.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/NewWorkoutDialog.kt
@@ -81,7 +81,7 @@ class NewWorkoutDialog : WorkoutController.AdapterCallbacks, DialogFragment() {
             WorkoutController(
                 ArrayAdapter(
                     requireContext(),
-                    android.R.layout.simple_spinner_item
+                    R.layout.dropdown_menu_popup_item
                 ), this
             )
 
@@ -105,7 +105,7 @@ class NewWorkoutDialog : WorkoutController.AdapterCallbacks, DialogFragment() {
 
         viewModel.exercises.observe(viewLifecycleOwner, Observer {
             val adapter = ArrayAdapter<String>(
-                requireContext(), android.R.layout.simple_spinner_item,
+                requireContext(), R.layout.dropdown_menu_popup_item,
                 viewModel.exercises.value?.map { it.name } ?: listOf())
             workoutController.setAdapter(adapter)
             recyclerView.setController(workoutController)

--- a/app/src/main/res/layout/dropdown_menu_popup_item.xml
+++ b/app/src/main/res/layout/dropdown_menu_popup_item.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:padding="16dp"
+        android:textAppearance="?attr/textAppearanceSubtitle1" />


### PR DESCRIPTION
## Old
<img width="313" alt="Screen Shot 2020-01-05 at 7 46 10 PM" src="https://user-images.githubusercontent.com/9154202/71788936-17bd5b00-2ff5-11ea-9bce-19a4c2f1d3ca.png">

## New
<img width="316" alt="Screen Shot 2020-01-05 at 7 51 29 PM" src="https://user-images.githubusercontent.com/9154202/71788943-2441b380-2ff5-11ea-958c-a0b8f8ea242e.png">

Borrowed from the Material Design Spec for [Exposed Dropdown Menu](https://material.io/develop/android/components/menu/)

