### PR TITLE
Fix Epoxy Diffing in Workouts

### DIFF
--- a/app/src/main/java/io/mochahub/powermeter/models/Workout.kt
+++ b/app/src/main/java/io/mochahub/powermeter/models/Workout.kt
@@ -1,6 +1,9 @@
 package io.mochahub.powermeter.models
 
+import java.util.UUID
+
 data class Workout(
+    val id: String = UUID.randomUUID().toString(),
     val exercise: Exercise,
     val sets: MutableList<WorkoutSet>
 )

--- a/app/src/main/java/io/mochahub/powermeter/models/WorkoutSet.kt
+++ b/app/src/main/java/io/mochahub/powermeter/models/WorkoutSet.kt
@@ -2,8 +2,10 @@ package io.mochahub.powermeter.models
 
 import io.mochahub.powermeter.models.WorkoutSet.Companion.REP_MAX_LIMIT
 import io.mochahub.powermeter.models.WorkoutSet.Companion.REP_MIN_LIMIT
+import java.util.UUID
 
 data class WorkoutSet(
+    val id: String = UUID.randomUUID().toString(),
     val weight: Double,
     val reps: Int = 0
 ) {

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/NewWorkoutDialog.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/NewWorkoutDialog.kt
@@ -118,8 +118,8 @@ class NewWorkoutDialog : WorkoutController.AdapterCallbacks, DialogFragment() {
 
     private fun addEmptyWorkout() {
         val workout = Workout(
-            Exercise("", 0.0, ""),
-            ArrayList()
+            exercise = Exercise("", 0.0, ""),
+            sets = ArrayList()
         )
         workouts.add(0, workout)
     }
@@ -159,7 +159,7 @@ class NewWorkoutDialog : WorkoutController.AdapterCallbacks, DialogFragment() {
     // Interface methods for workout controller
     // //////////////////////////////////////////////////////////////
     override fun onAddSetClicked(index: Int) {
-        workouts[index] = workouts[index].addSet(WorkoutSet(0.0, 0))
+        workouts[index] = workouts[index].addSet(WorkoutSet(weight = 0.0, reps = 0))
         workoutController.setData(workouts)
     }
 

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutController.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutController.kt
@@ -21,13 +21,13 @@ class WorkoutController(
             workoutRow(workout, arrayAdapter,
                 { callbacks.onAddSetClicked(workoutIndex) },
                 { value -> callbacks.onExerciseSelected(workoutIndex, value) }) {
-                id(workout.hashCode() + workoutIndex)
+                id(workout.id)
             }
             workout.sets.forEachIndexed { workoutSetIndex, workoutSet ->
                 workoutRowSet(workoutSet,
                     { value -> callbacks.onRepFocusChanged(workoutIndex, workoutSetIndex, value) },
                     { value -> callbacks.onWeightFocusChanged(workoutIndex, workoutSetIndex, value) }) {
-                    id(workoutSet.hashCode() + workoutSetIndex)
+                    id(workoutSet.id)
                 }
             }
         }


### PR DESCRIPTION
We were seeing a flashing of the entire Epoxy RecyclerView previously whenever any changes were made to the workout. This is because Epoxy was forced to reload everything every time because the `id`s being used in the controller were changing every time! 
1. Using `hashCode()` didn't work because the objects themselves were being mutated as values within them were changing
   - note that changing a set caused the whole workout to flash - because sets are children of workouts and if the set changed, so did the `hashCode()` of the workout it was in!
2. Using the index of the object would have done this even if ☝️ worked as expected

If this PR is approved, note that I didn't do any work in `NewWorkoutViewModel` since I haven't looked at it yet, but you might want to set the id of the Workout (Model) to be the same as the WorkoutEntity if there is a mapping yet 🤷‍♂ 