### PR TITLE
Use Flow for Exercises

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     // Lifecycle
     implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.1.0'
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.2.0-rc03"
 
     // App Center
     implementation "com.microsoft.appcenter:appcenter-analytics:${appCenterSdkVersion}"

--- a/app/src/main/java/io/mochahub/powermeter/data/ExerciseDao.kt
+++ b/app/src/main/java/io/mochahub/powermeter/data/ExerciseDao.kt
@@ -1,16 +1,16 @@
 package io.mochahub.powermeter.data
 
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ExerciseDao {
     @Query("SELECT * FROM exercises ORDER BY createdAt ASC")
-    fun getAll(): LiveData<List<ExerciseEntity>>
+    fun getAll(): Flow<List<ExerciseEntity>>
 
     @Insert
     suspend fun insertAll(vararg exercise: ExerciseEntity)

--- a/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseViewModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseViewModel.kt
@@ -2,32 +2,26 @@ package io.mochahub.powermeter.exercises
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import io.mochahub.powermeter.data.AppDatabase
 import io.mochahub.powermeter.data.ExerciseEntity
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class ExerciseViewModel(val db: AppDatabase) : ViewModel() {
-    val exercises: LiveData<List<ExerciseEntity>> = db.exerciseDao().getAll()
+    val exercises: LiveData<List<ExerciseEntity>> = db.exerciseDao().getAll().asLiveData()
 
     fun addExercise(exercise: ExerciseEntity) {
-        viewModelScope.launch(Dispatchers.IO) {
-            db.exerciseDao().insertAll(exercise)
-        }
+        viewModelScope.launch { db.exerciseDao().insertAll(exercise) }
     }
 
     fun removeExercise(position: Int): ExerciseEntity {
         val exercise = exercises.value!![position]
-        viewModelScope.launch(Dispatchers.IO) {
-            db.exerciseDao().delete(exercise)
-        }
+        viewModelScope.launch { db.exerciseDao().delete(exercise) }
         return exercise
     }
 
     fun updateExercise(exercise: ExerciseEntity) {
-        viewModelScope.launch(Dispatchers.IO) {
-            db.exerciseDao().updateExercise(exercise)
-        }
+        viewModelScope.launch { db.exerciseDao().updateExercise(exercise) }
     }
 }


### PR DESCRIPTION
1. Update `getAll()` Exercises to emit a `Flow` instead of `LiveData`
2. Turns out specifying `Dispatchers.IO` for the CoroutineContext was redundant with Room `suspend fun` as it does it automatically 

Here's a handy image comparing the use of `suspend fun` and `Flow` for Room:
![image](https://user-images.githubusercontent.com/9154202/72007048-dd370680-321e-11ea-8a61-902e6723a906.png)
