### PR TITLE
Update Github Workflow Dependencies

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,10 +17,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: set up python 3.8.0
+    - name: set up python 3
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8.0
+        python-version: '3.x'
     - name: Create Key Files
       run: python3 gh-actions-post-clone.py  ${{ secrets.app_center_secret }} ${{ secrets.firebase_dev_json }} ${{ secrets.firebase_prod_json }}
     - name: Build with Gradle and ktlint

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,10 +17,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: set up python 3.7.5
+    - name: set up python 3.8.0
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7.5
+        python-version: 3.8.0
     - name: Create Key Files
       run: python3 gh-actions-post-clone.py  ${{ secrets.app_center_secret }} ${{ secrets.firebase_dev_json }} ${{ secrets.firebase_prod_json }}
     - name: Build with Gradle and ktlint


### PR DESCRIPTION
- Updates python from 3.7.5 to latest python 3 version
- Python 3.7.5 is no longer supported in github actions