### PR TITLE
[PM-63] Remove new set button

### DIFF
--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutController.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutController.kt
@@ -33,29 +33,32 @@ class WorkoutController(
         workoutSession?.workouts?.forEach { workout ->
             workoutRow(
                 workout = workout,
-                toggleWorkoutSetVisibility = { visible -> this.callbacks.toggleWorkoutSetVisibility(visible, workout) },
+                toggleWorkoutSetVisibility = { visible -> callbacks.toggleWorkoutSetVisibility(visible, workout) },
                 arrayAdapter = ArrayAdapter(context, R.layout.dropdown_menu_popup_item, exercises),
-                addButtonClickListener = { callbacks.onAddSetClicked(workout) },
                 onExerciseSelected = { value -> callbacks.onExerciseSelected(workout, value) }) {
                 id(workout.id)
             }
             if (workout.isSetsVisible) {
-                workout.sets.forEach { workoutSet ->
+                workout.sets.forEachIndexed { setIndex, workoutSet ->
                     workoutRowSet(
                         workoutSet = workoutSet,
-                        onRepFocusChanged = { value ->
+                        lastSet = (setIndex == workout.sets.size - 1),
+                        onRepTextChanged = { value ->
                             callbacks.onRepTextChanged(
                                 workout,
                                 workoutSet,
                                 value
                             )
                         },
-                        onWeightFocusChanged = { value ->
+                        onWeightTextChanged = { value ->
                             callbacks.onWeightTextChanged(
                                 workout,
                                 workoutSet,
                                 value
                             )
+                        },
+                        lastSetFocused = {
+                            callbacks.onAddSetClicked(workout)
                         }) {
                         id(workoutSet.id)
                     }

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutController.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutController.kt
@@ -18,7 +18,7 @@ class WorkoutController(
 
     interface AdapterCallbacks {
         fun onExerciseSelected(workout: Workout, exercise: String)
-        fun onAddSetClicked(workout: Workout)
+        fun addEmptyWorkoutSet(workout: Workout)
         fun toggleWorkoutSetVisibility(visible: Boolean, workout: Workout)
         fun onRepTextChanged(workout: Workout, workoutSet: WorkoutSet, value: Int)
         fun onWeightTextChanged(workout: Workout, workoutSet: WorkoutSet, value: Double)
@@ -58,7 +58,7 @@ class WorkoutController(
                             )
                         },
                         lastSetFocused = {
-                            callbacks.onAddSetClicked(workout)
+                            callbacks.addEmptyWorkoutSet(workout)
                         }) {
                         id(workoutSet.id)
                     }

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutRowModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutRowModel.kt
@@ -14,7 +14,6 @@ import io.mochahub.powermeter.shared.KotlinEpoxyHolder
 abstract class WorkoutRowModel(
     @EpoxyAttribute var workout: Workout,
     @EpoxyAttribute var arrayAdapter: ArrayAdapter<String>,
-    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var addButtonClickListener: () -> Unit,
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var toggleWorkoutSetVisibility: (toggle: Boolean) -> Unit,
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var onExerciseSelected: (exercise: String) -> Unit
 ) : EpoxyModelWithHolder<WorkoutRowModel.Holder>() {
@@ -30,10 +29,6 @@ abstract class WorkoutRowModel(
             onExerciseSelected(holder.workoutExerciseTextView.text.toString())
         }
 
-        holder.addEmptyWorkoutSetButton.setOnClickListener {
-            toggleWorkoutSetVisibility(true)
-            addButtonClickListener()
-        }
         holder.toggleWorkoutSetVisibilityButton.setOnClickListener {
             toggleWorkoutSetVisibility(!workout.isSetsVisible)
             holder.toggleWorkoutSetVisibilityButton.rotation = if (workout.isSetsVisible) 0f else 180f
@@ -42,7 +37,6 @@ abstract class WorkoutRowModel(
 
     class Holder : KotlinEpoxyHolder() {
         val workoutExerciseTextView by bind<AutoCompleteTextView>(R.id.newWorkoutExerciseText)
-        val addEmptyWorkoutSetButton by bind<MaterialButton>(R.id.newWorkoutSetButton)
         val toggleWorkoutSetVisibilityButton by bind<MaterialButton>(R.id.toggleWorkoutSetVisibility)
     }
 }

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutRowSetModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutRowSetModel.kt
@@ -13,8 +13,10 @@ import io.mochahub.powermeter.shared.KotlinEpoxyHolder
 @EpoxyModelClass(layout = R.layout.row_workout_set_edit)
 abstract class WorkoutRowSetModel(
     @EpoxyAttribute var workoutSet: WorkoutSet,
-    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var onRepFocusChanged: (reps: Int) -> Unit,
-    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var onWeightFocusChanged: (weight: Double) -> Unit
+    @EpoxyAttribute var lastSet: Boolean,
+    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var onRepTextChanged: (reps: Int) -> Unit,
+    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var onWeightTextChanged: (weight: Double) -> Unit,
+    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var lastSetFocused: () -> Unit
 ) : EpoxyModelWithHolder<WorkoutRowSetModel.Holder>() {
 
     override fun bind(holder: Holder) {
@@ -37,18 +39,30 @@ abstract class WorkoutRowSetModel(
         if (holder.weightEditText.hasFocus() && holder.weightEditText.text != null) {
             holder.weightEditText.setSelection(holder.weightEditText.length())
         }
+
+        holder.repsEditText.setOnFocusChangeListener { _, _ ->
+            if (lastSet) {
+                lastSetFocused()
+            }
+        }
+
+        holder.weightEditText.setOnFocusChangeListener { _, _ ->
+            if (lastSet) {
+                lastSetFocused()
+            }
+        }
         holder.repsEditText.addTextChangedListener(WorkoutSetTextChangeListener {
             if (holder.repsEditText.text.toString().isNotEmpty() &&
                 holder.repsEditText.text.toString().isNotBlank()
             ) {
-                onRepFocusChanged(holder.repsEditText.text.toString().toInt())
+                onRepTextChanged(holder.repsEditText.text.toString().toInt())
             }
         })
         holder.weightEditText.addTextChangedListener(WorkoutSetTextChangeListener {
             if (holder.weightEditText.text.toString().isNotEmpty() &&
                 holder.weightEditText.text.toString().isNotBlank()
             ) {
-                onWeightFocusChanged(holder.weightEditText.text.toString().toDouble())
+                onWeightTextChanged(holder.weightEditText.text.toString().toDouble())
             }
         })
     }

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialog.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialog.kt
@@ -218,7 +218,7 @@ class WorkoutSessionDialog : WorkoutController.AdapterCallbacks, DialogFragment(
     // that causes out of bounds exceptions
     // TODO: make workouts a hashmap and change model so that workoutsets are a hashmap.
     //  The keys will be their ids.
-    override fun onAddSetClicked(workout: Workout) {
+    override fun addEmptyWorkoutSet(workout: Workout) {
         for (i in viewModel.workoutSession.workouts.indices) {
             if (viewModel.workoutSession.workouts[i].id == workout.id) {
                 (viewModel.workoutSession.workouts as ArrayList)[i] =

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialog.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialog.kt
@@ -201,6 +201,9 @@ class WorkoutSessionDialog : WorkoutController.AdapterCallbacks, DialogFragment(
                 it.forEach { workoutRelation ->
                     (viewModel.workoutSession.workouts as ArrayList).add(workoutRelation.toModel())
                 }
+                if (viewModel.workoutSession.workouts.isEmpty()) {
+                    this.addEmptyWorkout()
+                }
                 workoutController.setData(viewModel.workoutSession)
                 viewModel.isReady.postValue(true)
             })

--- a/app/src/main/res/layout/row_workout_edit.xml
+++ b/app/src/main/res/layout/row_workout_edit.xml
@@ -13,22 +13,6 @@
             android:layout_marginTop="16dp"
             android:background="@color/colorDivider"/>
 
-
-    <com.google.android.material.textfield.TextInputLayout
-            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:hint="@string/exercise">
-
-        <AutoCompleteTextView
-                android:id="@+id/newWorkoutExerciseText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:cursorVisible="false"
-                android:focusable="false" />
-
-    </com.google.android.material.textfield.TextInputLayout>
     <LinearLayout
             android:orientation="horizontal"
             android:layout_width="match_parent"
@@ -36,14 +20,24 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:gravity="center" >
-        <com.google.android.material.button.MaterialButton
-                android:id="@+id/newWorkoutSetButton"
+        <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                 android:layout_width="0dp"
+                android:layout_marginEnd="8dp"
                 android:layout_weight=".9"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:text="@string/new_set"
-                android:textColor="@android:color/white" />
+                android:hint="@string/exercise">
+
+            <AutoCompleteTextView
+                    android:id="@+id/newWorkoutExerciseText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:cursorVisible="false"
+                    android:focusable="false" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+
 
         <com.google.android.material.button.MaterialButton
                 android:id="@+id/toggleWorkoutSetVisibility"


### PR DESCRIPTION
Old behavior:

- `Add New Set` button creates a new workout set on click

New behavior:

- Removes the `Add New Set` button
- New workout set gets created when the last workout set is focused
- There should never be a case where there are no workout sets to focus

Additional Changes:

- Modified the conditions on which workout sessions get saved
- If empty sets exist, they don't get saved in the corresponding workout
- If empty exercises exist, that workout does not get saved