### PR TITLE
[Pm-80] WorkoutSession save logic + WorkoutSessionDao refactor

### DIFF
--- a/app/src/androidTest/java/io/mochahub/powermeter/RoomRelationTest.kt
+++ b/app/src/androidTest/java/io/mochahub/powermeter/RoomRelationTest.kt
@@ -69,7 +69,7 @@ class RoomRelationTest {
     @Test
     @Throws(Exception::class)
     fun getWorkoutSessionWithRelations() {
-        var workoutSessions = runBlocking { workoutSessionDao.getAllWithRelations().take(1).toList() }
+        var workoutSessions = runBlocking { workoutSessionDao.getAll().take(1).toList() }
 
         assertTrue(workoutSessions.isNotEmpty())
         assertTrue(workoutSessions.size == 1)

--- a/app/src/main/java/io/mochahub/powermeter/data/workoutsession/WorkoutSessionDao.kt
+++ b/app/src/main/java/io/mochahub/powermeter/data/workoutsession/WorkoutSessionDao.kt
@@ -10,21 +10,21 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface WorkoutSessionDao {
-    @Query("SELECT * FROM workout_sessions ORDER BY date DESC, createdAt DESC")
-    fun getAll(): Flow<List<WorkoutSessionEntity>>
-
     @Transaction
-    @Query("SELECT * FROM workout_sessions")
+    @Query("SELECT * FROM workout_sessions ORDER BY date DESC, createdAt DESC")
     fun getAllWithRelations(): Flow<List<WorkoutSessionWithRelation>>
 
-    @Query("DELETE FROM workout_sessions WHERE id = :workoutSessionID")
-    suspend fun deleteByID(workoutSessionID: String)
+    @Query("SELECT * FROM workout_sessions WHERE id = :workoutSessionID")
+    suspend fun find(workoutSessionID: String): WorkoutSessionEntity
 
     @Insert
     suspend fun insertAll(vararg workoutSession: WorkoutSessionEntity)
 
     @Delete
     suspend fun delete(workoutSession: WorkoutSessionEntity)
+
+    @Query("DELETE FROM workout_sessions WHERE id = :workoutSessionID")
+    suspend fun delete(workoutSessionID: String)
 
     @Update
     suspend fun update(vararg workoutSession: WorkoutSessionEntity)

--- a/app/src/main/java/io/mochahub/powermeter/data/workoutsession/WorkoutSessionDao.kt
+++ b/app/src/main/java/io/mochahub/powermeter/data/workoutsession/WorkoutSessionDao.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
 interface WorkoutSessionDao {
     @Transaction
     @Query("SELECT * FROM workout_sessions ORDER BY date DESC, createdAt DESC")
-    fun getAllWithRelations(): Flow<List<WorkoutSessionWithRelation>>
+    fun getAll(): Flow<List<WorkoutSessionWithRelation>>
 
     @Query("SELECT * FROM workout_sessions WHERE id = :workoutSessionID")
     suspend fun find(workoutSessionID: String): WorkoutSessionEntity

--- a/app/src/main/java/io/mochahub/powermeter/data/workoutsession/WorkoutSessionEntity.kt
+++ b/app/src/main/java/io/mochahub/powermeter/data/workoutsession/WorkoutSessionEntity.kt
@@ -11,3 +11,7 @@ data class WorkoutSessionEntity(
     var date: Long,
     val createdAt: Long = Instant.now().epochSecond
 )
+
+fun WorkoutSessionEntity.setCreatedAt(newCreatedAt: Long): WorkoutSessionEntity {
+    return this.copy(createdAt = newCreatedAt)
+}

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/WorkoutSessionViewModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/WorkoutSessionViewModel.kt
@@ -22,7 +22,7 @@ class WorkoutSessionViewModel(
     fun removeWorkoutSession(position: Int): WorkoutSessionWithRelation {
         val workoutSession = workoutSessions.value!![position]
         viewModelScope.launch {
-            workoutSessionDao.deleteByID(workoutSession.workoutSession.id)
+            workoutSessionDao.delete(workoutSession.workoutSession.id)
         }
         return workoutSession
     }

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/WorkoutSessionViewModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/WorkoutSessionViewModel.kt
@@ -17,7 +17,7 @@ class WorkoutSessionViewModel(
     private val workoutSetDao: WorkoutSetDao
 ) : ViewModel() {
     val workoutSessions: LiveData<List<WorkoutSessionWithRelation>> =
-        workoutSessionDao.getAllWithRelations().asLiveData()
+        workoutSessionDao.getAll().asLiveData()
 
     fun removeWorkoutSession(position: Int): WorkoutSessionWithRelation {
         val workoutSession = workoutSessions.value!![position]


### PR DESCRIPTION
- When editing a session, get the previous `createdAt` time so that ordering stays the same
- Remove unused methods
- Orde the return of `GetAll` for `WorkoutSessionDao`