### PR TITLE
[Pm-79] Delete workout

### DIFF
--- a/app/src/main/java/io/mochahub/powermeter/models/WorkoutSession.kt
+++ b/app/src/main/java/io/mochahub/powermeter/models/WorkoutSession.kt
@@ -14,3 +14,13 @@ fun WorkoutSession.setDate(epochSecondDate: Long): WorkoutSession {
 fun WorkoutSession.setDate(newDate: Instant): WorkoutSession {
     return this.copy(date = newDate)
 }
+
+fun WorkoutSession.removeWorkout(workout: Workout): WorkoutSession {
+    val workoutList = workouts.toMutableList().apply { this.remove(workout) }
+    return this.copy(workouts = workoutList)
+}
+
+fun WorkoutSession.addWorkout(workout: Workout): WorkoutSession {
+    val workoutList = workouts.toMutableList().apply { this.add(workout) }
+    return this.copy(workouts = workoutList)
+}

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutController.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutController.kt
@@ -18,6 +18,7 @@ class WorkoutController(
 
     interface AdapterCallbacks {
         fun onExerciseSelected(workout: Workout, exercise: String)
+        fun onWorkoutDeleteClickListener(workout: Workout)
         fun addEmptyWorkoutSet(workout: Workout)
         fun toggleWorkoutSetVisibility(visible: Boolean, workout: Workout)
         fun onRepTextChanged(workout: Workout, workoutSet: WorkoutSet, value: Int)
@@ -37,9 +38,8 @@ class WorkoutController(
                     callbacks.toggleWorkoutSetVisibility(visible, workout)
                 },
                 arrayAdapter = ArrayAdapter(context, R.layout.dropdown_menu_popup_item, exercises),
-                onExerciseSelected = { value ->
-                    callbacks.onExerciseSelected(workout, value)
-                }
+                onExerciseSelected = { value -> callbacks.onExerciseSelected(workout, value) },
+                onWorkoutDeleteClickListener = { callbacks.onWorkoutDeleteClickListener(workout) }
             ) {
                 id(workout.id)
             }
@@ -62,9 +62,8 @@ class WorkoutController(
                                 value
                             )
                         },
-                        lastSetFocused = {
-                            callbacks.addEmptyWorkoutSet(workout)
-                        }) {
+                        lastSetFocused = { callbacks.addEmptyWorkoutSet(workout) }
+                    ) {
                         id(workoutSet.id)
                     }
                 }

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutRowModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutRowModel.kt
@@ -15,14 +15,14 @@ abstract class WorkoutRowModel(
     @EpoxyAttribute var workout: Workout,
     @EpoxyAttribute var arrayAdapter: ArrayAdapter<String>,
     @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var toggleWorkoutSetVisibility: (toggle: Boolean) -> Unit,
-    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var onExerciseSelected: (exercise: String) -> Unit
+    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var onExerciseSelected: (exercise: String) -> Unit,
+    @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash) var onWorkoutDeleteClickListener: () -> Unit
 ) : EpoxyModelWithHolder<WorkoutRowModel.Holder>() {
 
     override fun bind(holder: Holder) {
 
-        if (workout.exercise.name.isNotBlank()) {
-            holder.workoutExerciseTextView.setText(workout.exercise.name)
-        }
+        holder.workoutExerciseTextView.setText(
+            if (workout.exercise.name.isNotBlank()) workout.exercise.name else "")
         holder.workoutExerciseTextView.setAdapter(arrayAdapter)
 
         holder.workoutExerciseTextView.setOnItemClickListener { _, _, _, _ ->
@@ -34,10 +34,15 @@ abstract class WorkoutRowModel(
         }
         holder.toggleWorkoutSetVisibilityButton.rotation =
             if (workout.isSetsVisible) 180f else 0f
+
+        holder.deleteWorkoutButton.setOnClickListener {
+            onWorkoutDeleteClickListener()
+        }
     }
 
     class Holder : KotlinEpoxyHolder() {
         val workoutExerciseTextView by bind<AutoCompleteTextView>(R.id.newWorkoutExerciseText)
         val toggleWorkoutSetVisibilityButton by bind<MaterialButton>(R.id.toggleWorkoutSetVisibility)
+        val deleteWorkoutButton by bind<MaterialButton>(R.id.deleteWorkoutButton)
     }
 }

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutRowSetModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutRowSetModel.kt
@@ -20,11 +20,8 @@ abstract class WorkoutRowSetModel(
 ) : EpoxyModelWithHolder<WorkoutRowSetModel.Holder>() {
 
     override fun bind(holder: Holder) {
-        if (workoutSet.reps != 0) {
-            holder.repsEditText.setText(workoutSet.reps.toString())
-        } else {
-            holder.repsEditText.setText("")
-        }
+        holder.repsEditText.setText(if (workoutSet.reps != 0) workoutSet.reps.toString() else "")
+
         if (workoutSet.weight != 0.0) {
             // We do not want to display 1.0 when the user simply inputs 1
             if (workoutSet.weight % 1 == 0.0) {

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutRowSetModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutRowSetModel.kt
@@ -22,6 +22,8 @@ abstract class WorkoutRowSetModel(
     override fun bind(holder: Holder) {
         if (workoutSet.reps != 0) {
             holder.repsEditText.setText(workoutSet.reps.toString())
+        } else {
+            holder.repsEditText.setText("")
         }
         if (workoutSet.weight != 0.0) {
             // We do not want to display 1.0 when the user simply inputs 1
@@ -30,6 +32,8 @@ abstract class WorkoutRowSetModel(
             } else {
                 holder.weightEditText.setText(workoutSet.weight.toString())
             }
+        } else {
+            holder.weightEditText.setText("")
         }
 
         // Move cursor to the end

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialog.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialog.kt
@@ -18,7 +18,9 @@ import io.mochahub.powermeter.models.Exercise
 import io.mochahub.powermeter.models.Workout
 import io.mochahub.powermeter.models.WorkoutSet
 import io.mochahub.powermeter.models.addSet
+import io.mochahub.powermeter.models.addWorkout
 import io.mochahub.powermeter.models.removeSet
+import io.mochahub.powermeter.models.removeWorkout
 import io.mochahub.powermeter.models.setDate
 import io.mochahub.powermeter.models.setReps
 import io.mochahub.powermeter.models.setVisibility
@@ -145,7 +147,7 @@ class WorkoutSessionDialog : WorkoutController.AdapterCallbacks, DialogFragment(
             exercise = Exercise("", 0.0, ""),
             sets = sets
         )
-        (viewModel.workoutSession.workouts as ArrayList).add(workout)
+        viewModel.workoutSession = viewModel.workoutSession.addWorkout(workout)
         workoutController.setData(viewModel.workoutSession)
     }
 
@@ -287,5 +289,10 @@ class WorkoutSessionDialog : WorkoutController.AdapterCallbacks, DialogFragment(
                 workoutController.setData(viewModel.workoutSession)
             }
         }
+    }
+
+    override fun onWorkoutDeleteClickListener(workout: Workout) {
+        viewModel.workoutSession = viewModel.workoutSession.removeWorkout(workout)
+        workoutController.setData(viewModel.workoutSession)
     }
 }

--- a/app/src/main/res/layout/row_workout_edit.xml
+++ b/app/src/main/res/layout/row_workout_edit.xml
@@ -24,7 +24,7 @@
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                 android:layout_width="0dp"
                 android:layout_marginEnd="8dp"
-                android:layout_weight=".9"
+                android:layout_weight=".8"
                 android:layout_height="wrap_content"
                 android:hint="@string/exercise">
 
@@ -37,7 +37,15 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
-
+        <com.google.android.material.button.MaterialButton
+                android:id="@+id/deleteWorkoutButton"
+                style="@style/Widget.AppTheme.Button.IconButton"
+                android:layout_width="0dp"
+                android:layout_weight=".1"
+                android:layout_marginStart="8dp"
+                android:layout_height="wrap_content"
+                app:iconTint="@color/delete"
+                app:icon="@drawable/ic_delete_white_24dp"/>
 
         <com.google.android.material.button.MaterialButton
                 android:id="@+id/toggleWorkoutSetVisibility"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="colorPrimary">#008577</color>
+    <color name="delete">#FF5B5B</color>
     <color name="colorPrimaryDark">#00574B</color>
     <color name="colorAccent">#D81B60</color>
-
     <color name="colorDivider">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="colorPrimary">#008577</color>
+    <color name="delete">#FF0000</color>
     <color name="colorPrimaryDark">#00574B</color>
     <color name="colorAccent">#D81B60</color>
 


### PR DESCRIPTION
- Delete workout feature

Additional Changes:  
Found the cause of phantom values appearing in epoxy. It seems like when we delete items, epoxy caches these values? So if you deleted something, and added a new set/workout right after it would have values from the previous instances, even if the data didn't have. I went around this by explicitly always setting a value.