### PR TITLE
[PM-84] Update WorkoutSession Date to Correct Value

### DIFF
--- a/app/src/main/java/io/mochahub/powermeter/data/workoutsession/WorkoutSessionEntity.kt
+++ b/app/src/main/java/io/mochahub/powermeter/data/workoutsession/WorkoutSessionEntity.kt
@@ -15,3 +15,7 @@ data class WorkoutSessionEntity(
 fun WorkoutSessionEntity.setCreatedAt(newCreatedAt: Long): WorkoutSessionEntity {
     return this.copy(createdAt = newCreatedAt)
 }
+
+fun WorkoutSessionEntity.setDate(newDate: Instant): WorkoutSessionEntity {
+    return this.copy(date = newDate.epochSecond)
+}

--- a/app/src/main/java/io/mochahub/powermeter/models/WorkoutSession.kt
+++ b/app/src/main/java/io/mochahub/powermeter/models/WorkoutSession.kt
@@ -1,8 +1,10 @@
 package io.mochahub.powermeter.models
 
 import java.time.Instant
+import java.util.UUID
 
 data class WorkoutSession(
+    val id: String = UUID.randomUUID().toString(),
     val date: Instant = Instant.now(),
     val workouts: List<Workout>
 )

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutController.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutController.kt
@@ -28,7 +28,7 @@ class WorkoutController(
     override fun buildModels(workoutSession: WorkoutSession?) {
         if (workoutSession != null) {
             workoutSessionDate(workoutSession.date, datePickerDialog) {
-                id(workoutSession.date.toString())
+                id(workoutSession.id)
             }
         }
         workoutSession?.workouts?.forEach { workout ->

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialog.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialog.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.navArgs
 import com.airbnb.epoxy.EpoxyTouchHelper
+import io.mochahub.powermeter.BuildConfig
 import io.mochahub.powermeter.R
 import io.mochahub.powermeter.data.AppDatabase
 import io.mochahub.powermeter.data.exercise.ExerciseEntity
@@ -94,6 +95,10 @@ class WorkoutSessionDialog : WorkoutController.AdapterCallbacks, DialogFragment(
     private fun onViewCreatedReady() {
         recyclerView.setController(workoutController)
         workoutController.setData(viewModel.workoutSession)
+
+        if (BuildConfig.DEBUG) {
+            workoutController.isDebugLoggingEnabled = true
+        }
 
         EpoxyTouchHelper.initSwiping(recyclerView)
             .left()

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialogViewModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialogViewModel.kt
@@ -13,6 +13,7 @@ import io.mochahub.powermeter.data.workout.WorkoutEntity
 import io.mochahub.powermeter.data.workout.WorkoutWithRelation
 import io.mochahub.powermeter.data.workoutsession.WorkoutSessionEntity
 import io.mochahub.powermeter.data.workoutsession.setCreatedAt
+import io.mochahub.powermeter.data.workoutsession.setDate
 import io.mochahub.powermeter.data.workoutset.WorkoutSetEntity
 import io.mochahub.powermeter.models.WorkoutSession
 import kotlinx.coroutines.CoroutineScope
@@ -29,6 +30,7 @@ class WorkoutSessionDialogViewModel(
     }
 
     var workoutSession = WorkoutSession(workouts = ArrayList())
+
     private var workoutSessionEntity =
         WorkoutSessionEntity(date = workoutSession.date.epochSecond)
 
@@ -46,6 +48,7 @@ class WorkoutSessionDialogViewModel(
         val workoutEntities = ArrayList<WorkoutEntity>()
         val workoutSetEntities = ArrayList<WorkoutSetEntity>()
 
+        workoutSessionEntity = workoutSessionEntity.setDate(workoutSession.date)
         CoroutineScope(Dispatchers.IO).launch {
             workoutSessionToDelete?.let {
                 // There is an edge-case where we change system Theme via android settings


### PR DESCRIPTION
Bug:
- Editing or saving a workoutsession will change the date to the current date.

Solution:
- I forgot to actually update the entity with the date

Additional Changes:
- Added debug logging for epoxy 
- Added id on WorkoutSession model 