### PR TITLE
[PM-88] Exercise New/Edit Bug

### DIFF
--- a/app/src/main/java/io/mochahub/powermeter/data/exercise/ExerciseDao.kt
+++ b/app/src/main/java/io/mochahub/powermeter/data/exercise/ExerciseDao.kt
@@ -15,7 +15,7 @@ interface ExerciseDao {
     fun getAll(): Flow<List<ExerciseEntity>>
 
     @Query("SELECT * FROM exercises where name=:exerciseName")
-    suspend fun findByName(exerciseName: String): ExerciseEntity
+    suspend fun findByName(exerciseName: String): ExerciseEntity?
 
     @Query("SELECT * FROM exercises where id=:exerciseID")
     suspend fun findByID(exerciseID: String): ExerciseEntity

--- a/app/src/main/java/io/mochahub/powermeter/data/exercise/ExerciseEntity.kt
+++ b/app/src/main/java/io/mochahub/powermeter/data/exercise/ExerciseEntity.kt
@@ -20,30 +20,6 @@ fun ExerciseEntity.toModel(): Exercise {
         name = this.name, personalRecord = this.personalRecord, muscleGroup = this.muscleGroup)
 }
 
-fun ExerciseEntity.update(
-    newName: String,
-    newMuscleGroup: String,
-    newPersonalRecord: Double
-): ExerciseEntity {
-    return this.copy(
-        name = newName,
-        muscleGroup = newMuscleGroup,
-        personalRecord = newPersonalRecord)
-}
-
-fun ExerciseEntity.update(
-    id: String,
-    newName: String,
-    newMuscleGroup: String,
-    newPersonalRecord: Double
-): ExerciseEntity {
-    return this.copy(
-        id = id,
-        name = newName,
-        muscleGroup = newMuscleGroup,
-        personalRecord = newPersonalRecord)
-}
-
 fun ExerciseEntity.update(newPersonalRecord: Double): ExerciseEntity {
     return this.copy(personalRecord = newPersonalRecord)
 }

--- a/app/src/main/java/io/mochahub/powermeter/data/exercise/ExerciseEntity.kt
+++ b/app/src/main/java/io/mochahub/powermeter/data/exercise/ExerciseEntity.kt
@@ -31,6 +31,19 @@ fun ExerciseEntity.update(
         personalRecord = newPersonalRecord)
 }
 
+fun ExerciseEntity.update(
+    id: String,
+    newName: String,
+    newMuscleGroup: String,
+    newPersonalRecord: Double
+): ExerciseEntity {
+    return this.copy(
+        id = id,
+        name = newName,
+        muscleGroup = newMuscleGroup,
+        personalRecord = newPersonalRecord)
+}
+
 fun ExerciseEntity.update(newPersonalRecord: Double): ExerciseEntity {
     return this.copy(personalRecord = newPersonalRecord)
 }

--- a/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseDialog.kt
+++ b/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseDialog.kt
@@ -23,7 +23,7 @@ class ExerciseDialog : DialogFragment() {
             ViewModelProvider(
                 this,
                 ExerciseDialogViewModel.ExerciseDialogViewModelFactory(
-                    AppDatabase(requireContext()).exerciseDao(), args
+                    AppDatabase(requireContext()).exerciseDao()
                 )
             ).get(ExerciseDialogViewModel::class.java)
         }
@@ -54,15 +54,15 @@ class ExerciseDialog : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val exercise = viewModel.getExercise()
 
-        if (exercise.name.isNotBlank()) {
+        if (newExerciseNameText.text.isNullOrBlank() && args.exerciseName.isNotBlank()) {
             newExerciseNameText.setText(args.exerciseName)
         }
-        if (exercise.personalRecord != 0.0) {
+
+        if (newExercisePRText.text.isNullOrBlank() && args.exercisePR != 0f) {
             newExercisePRText.setText(args.exercisePR.toString())
         }
-        if (exercise.muscleGroup.isNotBlank()) {
+        if (newExerciseGroupText.text.isNullOrBlank() && args.muscleGroup.isNotBlank()) {
             newExerciseGroupText.setText(args.muscleGroup)
         }
 
@@ -77,6 +77,7 @@ class ExerciseDialog : DialogFragment() {
                 when (item?.itemId) {
                     R.id.action_save -> {
                         viewModel.upsertExercise(
+                            args.exerciseId,
                             newExerciseNameText.text.toString(),
                             newExerciseGroupText.text.toString(),
                             newExercisePRText.text.toString().toDoubleOrZero())

--- a/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseDialogViewModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseDialogViewModel.kt
@@ -32,7 +32,7 @@ class ExerciseDialogViewModel(
         CoroutineScope(Dispatchers.IO).launch {
             val exerciseFound = exerciseDao.findByName(name)
             // TODO: Inform user that exercise already exists
-            if (exerciseFound == null) {
+            if ((id.isBlank() && exerciseFound == null) || id.isNotBlank()) {
                 exerciseDao.upsert(exercise)
             }
         }

--- a/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseDialogViewModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/exercises/ExerciseDialogViewModel.kt
@@ -4,44 +4,37 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import io.mochahub.powermeter.data.exercise.ExerciseDao
 import io.mochahub.powermeter.data.exercise.ExerciseEntity
-import io.mochahub.powermeter.data.exercise.update
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class ExerciseDialogViewModel(
-    private val exerciseDao: ExerciseDao,
-    args: ExerciseDialogArgs
+    private val exerciseDao: ExerciseDao
 ) : ViewModel() {
 
     @Suppress("UNCHECKED_CAST")
     class ExerciseDialogViewModelFactory(
-        private val exerciseDao: ExerciseDao,
-        private val args: ExerciseDialogArgs
+        private val exerciseDao: ExerciseDao
     ) : ViewModelProvider.NewInstanceFactory() {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return ExerciseDialogViewModel(exerciseDao, args) as T
+            return ExerciseDialogViewModel(exerciseDao) as T
         }
     }
 
-    private var exercise = ExerciseEntity(
-        args.exerciseId,
-        args.exerciseName,
-        args.muscleGroup,
-        args.exercisePR.toDouble()
-    )
-
-    fun upsertExercise(name: String, muscleGroup: String, personalRecord: Double) {
-        exercise = exercise.update(name, muscleGroup, personalRecord)
-        if (exercise.name.isBlank()) {
+    fun upsertExercise(id: String, name: String, muscleGroup: String, personalRecord: Double) {
+        if (name.isBlank()) {
             return
         }
-        CoroutineScope(Dispatchers.IO).launch {
-            exerciseDao.upsert(exercise)
-        }
-    }
+        val exercise =
+            if (id.isNotBlank()) ExerciseEntity(id, name, muscleGroup, personalRecord)
+            else ExerciseEntity(name = name, muscleGroup = muscleGroup, personalRecord = personalRecord)
 
-    fun getExercise(): ExerciseEntity {
-        return this.exercise.copy()
+        CoroutineScope(Dispatchers.IO).launch {
+            val exerciseFound = exerciseDao.findByName(name)
+            // TODO: Inform user that exercise already exists
+            if (exerciseFound == null) {
+                exerciseDao.upsert(exercise)
+            }
+        }
     }
 }

--- a/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialogViewModel.kt
+++ b/app/src/main/java/io/mochahub/powermeter/workoutsession/workoutsessiondialog/WorkoutSessionDialogViewModel.kt
@@ -70,7 +70,7 @@ class WorkoutSessionDialogViewModel(
                 val exercise = db.exerciseDao().findByName(workout.exercise.name)
                 val workoutEntity = WorkoutEntity(
                     workoutSessionUUID = workoutSessionEntity.id,
-                    exerciseUUID = exercise.id
+                    exerciseUUID = exercise!!.id
                 )
                 workoutEntities.add(workoutEntity)
                 workout.sets.forEach { workoutSet ->


### PR DESCRIPTION
Bug: When adding two or more exercises in a row
- The first one gets added
- The second one updates the first one

This is caused by the fact that the ViewModel does not get recreated. The solution was actually just to make the logic simpler. This leverages the fact that `InputText` already handles config changes (rotate, theme change) internally to keep the text the same before and after a change so we don't need to worry about that.